### PR TITLE
modify encode_video() / encode_audio() API design

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It supports seven models, four features (video and audio features), and six data
 Furthermore, Lighthouse supports [audio moment retrieval](https://h-munakata.github.io/Language-based-Audio-Moment-Retrieval/), a task to identify relevant moments from an audio input based on a given text query.
 
 ## News
-- [2025/05/**] [Version 1.1]() has been released.
+- [2025/05/19] [Version 1.1]() has been released.
 - [2024/12/24] Our work ["Language-based audio moment retrieval"](https://arxiv.org/abs/2409.15672) has been accepted at ICASSP 2025.
 - [2024/10/22] [Version 1.0](https://github.com/line/lighthouse/releases/tag/v1.0) has been released.
 - [2024/10/6] Our paper has been accepted at EMNLP2024, system demonstration track.
@@ -44,7 +44,7 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 
 # slowfast_path is necesary if you use clip_slowfast features
 query = 'A man is speaking in front of the camera'
-model = CGDETRPredictor('results/cg_detr/qvhighlight/clip_slowfast/best.ckpt', device=device,
+model = CGDETRPredictor('/path/to/weight.ckpt', device=device,
                         feature_name='clip_slowfast', slowfast_path='SLOWFAST_8x8_R50.pkl')
 
 # encode video features
@@ -68,7 +68,20 @@ pred_saliency_scores: [score, ...]
                           ...]}
 """
 ```
-Run `python api_example/demo.py` to reproduce the results. It automatically downloads pre-trained weights for CG-DETR (CLIP backbone).
+Lighthouse also supports the AMR inference API:
+```python
+import torch
+from lighthouse.models import QDDETRPredictor
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+model = QDDETRPredictor('/path/to/weight.ckpt', device=device, feature_name='clap')
+
+audio = model.encode_audio('api_example/1a-ODBWMUAE.wav')
+query = 'Water cascades down from a waterfall.'
+prediction = model.predict(query, audio)
+print(prediction)
+```
+Run `python api_example/demo.py` (MR-HD) or `python api_example/amr_demo.py` (AMR) to reproduce the results. It automatically downloads pre-trained weights.
 If you want to use other models, download [pre-trained weights](https://drive.google.com/file/d/1jxs_bvwttXTF9Lk3aKLohkqfYOonLyrO/view?usp=sharing). 
 When using `clip_slowfast` features, it is necessary to download [slowfast pre-trained weights](https://dl.fbaipublicfiles.com/pyslowfast/model_zoo/kinetics400/SLOWFAST_8x8_R50.pkl).
 When using `clip_slowfast_pann` features, in addition to the slowfast weight, download [panns weights](https://zenodo.org/record/3987831/files/Cnn14_mAP%3D0.431.pth).
@@ -96,6 +109,7 @@ Moment retrieval & highlight detection
 - [x] : [UVCOM (Xiao et al. CVPR24)](https://arxiv.org/abs/2311.16464)
 - [x] : [TR-DETR (Sun et al. AAAI24)](https://arxiv.org/abs/2401.02309)
 - [x] : [TaskWeave (Jin et al. CVPR24)](https://arxiv.org/abs/2404.09263)
+- [ ] : [R2-Tuning (Liu et al. ECCV24)](https://arxiv.org/abs/2404.00801)
 
 ### Datasets
 Moment retrieval & highlight detection

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It supports seven models, four features (video and audio features), and six data
 Furthermore, Lighthouse supports [audio moment retrieval](https://h-munakata.github.io/Language-based-Audio-Moment-Retrieval/), a task to identify relevant moments from an audio input based on a given text query.
 
 ## News
+- [2025/05/**] [Version 1.1]() has been released.
 - [2024/12/24] Our work ["Language-based audio moment retrieval"](https://arxiv.org/abs/2409.15672) has been accepted at ICASSP 2025.
 - [2024/10/22] [Version 1.0](https://github.com/line/lighthouse/releases/tag/v1.0) has been released.
 - [2024/10/6] Our paper has been accepted at EMNLP2024, system demonstration track.
@@ -47,10 +48,10 @@ model = CGDETRPredictor('results/cg_detr/qvhighlight/clip_slowfast/best.ckpt', d
                         feature_name='clip_slowfast', slowfast_path='SLOWFAST_8x8_R50.pkl')
 
 # encode video features
-model.encode_video('api_example/RoripwjYFp8_60.0_210.0.mp4')
+video = model.encode_video('api_example/RoripwjYFp8_60.0_210.0.mp4')
 
 # moment retrieval & highlight detection
-prediction = model.predict(query)
+prediction = model.predict(query, video)
 print(prediction)
 """
 pred_relevant_windows: [[start, end, score], ...,]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It supports seven models, four features (video and audio features), and six data
 Furthermore, Lighthouse supports [audio moment retrieval](https://h-munakata.github.io/Language-based-Audio-Moment-Retrieval/), a task to identify relevant moments from an audio input based on a given text query.
 
 ## News
-- [2025/05/19] [Version 1.1]() has been released.
+- [2025/05/20] [Version 1.1]() has been released. It includes API changes and AMR gradio demo.
 - [2024/12/24] Our work ["Language-based audio moment retrieval"](https://arxiv.org/abs/2409.15672) has been accepted at ICASSP 2025.
 - [2024/10/22] [Version 1.0](https://github.com/line/lighthouse/releases/tag/v1.0) has been released.
 - [2024/10/6] Our paper has been accepted at EMNLP2024, system demonstration track.

--- a/api_example/amr_demo.py
+++ b/api_example/amr_demo.py
@@ -33,9 +33,9 @@ load_weights(weight_dir)
 model: QDDETRPredictor = QDDETRPredictor(weight_path, device=device, feature_name='clap')
 
 # encode audio features
-model.encode_audio('api_example/1a-ODBWMUAE.wav')
+audio = model.encode_audio('api_example/1a-ODBWMUAE.wav')
 
 # moment retrieval
 query: str = 'Water cascades down from a waterfall.'
-prediction: Optional[Dict[str, List[float]]] = model.predict(query)
+prediction: Optional[Dict[str, List[float]]] = model.predict(query, audio)
 print(prediction)

--- a/api_example/demo.py
+++ b/api_example/demo.py
@@ -21,8 +21,8 @@ from lighthouse.models import CGDETRPredictor
 from typing import Dict, List, Optional
 
 def load_weights(weight_dir: str) -> None:
-    if not os.path.exists(os.path.join(weight_dir, 'clip_slowfast_pann_cg_detr_qvhighlight.ckpt')):  
-        command = 'wget -P gradio_demo/weights/ https://zenodo.org/records/13960580/files/clip_slowfast_pann_cg_detr_qvhighlight.ckpt'
+    if not os.path.exists(os.path.join(weight_dir, 'clip_slowfast_cg_detr_qvhighlight.ckpt')):  
+        command = 'wget -P gradio_demo/weights/ https://zenodo.org/records/13960580/files/clip_slowfast_cg_detr_qvhighlight.ckpt'
         subprocess.run(command, shell=True)
 
     if not os.path.exists('SLOWFAST_8x8_R50.pkl'):

--- a/api_example/demo.py
+++ b/api_example/demo.py
@@ -40,9 +40,9 @@ model: CGDETRPredictor = CGDETRPredictor(weight_path, device=device, feature_nam
                                          slowfast_path='SLOWFAST_8x8_R50.pkl', pann_path=None)
 
 # encode video features
-model.encode_video('api_example/RoripwjYFp8_60.0_210.0.mp4')
+video = model.encode_video('api_example/RoripwjYFp8_60.0_210.0.mp4')
 
 # moment retrieval & highlight detection
 query: str = 'A woman wearing a glass is speaking in front of the camera'
-prediction: Optional[Dict[str, List[float]]] = model.predict(query)
+prediction: Optional[Dict[str, List[float]]] = model.predict(query, video)
 print(prediction)

--- a/gradio_demo/amr_demo.py
+++ b/gradio_demo/amr_demo.py
@@ -55,19 +55,20 @@ Model initialization
 """
 load_pretrained_weights()
 model = QDDETRPredictor('gradio_demo/weights/clap_qd_detr_clotho-moment.ckpt', device=device, feature_name='clap')
-model.audio = None
+loaded_audio = None
 
 """
 Gradio functions
 """
 def audio_upload(audio):
+    global loaded_audio
     if audio is None:
-        model.audio = None
+        loaded_audio = None
         yield gr.update(value="Removed the audio", visible=True)
     else:
         yield gr.update(value="Processing the audio. Wait for a minute...", visible=True)
         audio_feats = model.encode_audio(audio)
-        model.audio = audio_feats
+        loaded_audio = audio_feats
         yield gr.update(value="Finished audio processing!", visible=True)
 
 def model_load(radio):
@@ -87,10 +88,11 @@ def model_load(radio):
         yield gr.update(value="Model loaded: {}".format(radio), visible=True)
 
 def predict(textbox, line, gallery):
-    if model.audio is None:
+    global loaded_audio
+    if loaded_audio is None:
         raise gr.Error('Upload the audio before pushing the `Retrieve moment` button.')
     else:
-        prediction = model.predict(textbox, model.audio)
+        prediction = model.predict(textbox, loaded_audio)
         mr_results = prediction['pred_relevant_windows']
 
         buttons = []

--- a/gradio_demo/amr_demo.py
+++ b/gradio_demo/amr_demo.py
@@ -61,11 +61,12 @@ Gradio functions
 """
 def audio_upload(audio):
     if audio is None:
-        model.audio_feats = None
+        model.audio = None
         yield gr.update(value="Removed the audio", visible=True)
     else:
         yield gr.update(value="Processing the audio. Wait for a minute...", visible=True)
-        model.encode_audio(audio)
+        audio_feats = model.encode_audio(audio)
+        model.audio = audio_feats
         yield gr.update(value="Finished audio processing!", visible=True)
 
 def model_load(radio):
@@ -85,7 +86,7 @@ def model_load(radio):
         yield gr.update(value="Model loaded: {}".format(radio), visible=True)
 
 def predict(textbox, line, gallery):
-    prediction = model.predict(textbox)
+    prediction = model.predict(textbox, model.audio)
     if prediction is None:
         raise gr.Error('Upload the audio before pushing the `Retrieve moment` button.')
     else:

--- a/gradio_demo/amr_demo.py
+++ b/gradio_demo/amr_demo.py
@@ -55,6 +55,7 @@ Model initialization
 """
 load_pretrained_weights()
 model = QDDETRPredictor('gradio_demo/weights/clap_qd_detr_clotho-moment.ckpt', device=device, feature_name='clap')
+model.audio = None
 
 """
 Gradio functions
@@ -86,10 +87,10 @@ def model_load(radio):
         yield gr.update(value="Model loaded: {}".format(radio), visible=True)
 
 def predict(textbox, line, gallery):
-    prediction = model.predict(textbox, model.audio)
-    if prediction is None:
+    if model.audio is None:
         raise gr.Error('Upload the audio before pushing the `Retrieve moment` button.')
     else:
+        prediction = model.predict(textbox, model.audio)
         mr_results = prediction['pred_relevant_windows']
 
         buttons = []

--- a/gradio_demo/demo.py
+++ b/gradio_demo/demo.py
@@ -66,8 +66,8 @@ Model initialization
 load_pretrained_weights()
 model = CGDETRPredictor('gradio_demo/weights/clip_cg_detr_qvhighlight.ckpt', device=device, 
                         feature_name='clip', slowfast_path=None, pann_path=None)
-model.video = None
-model.video_path = None
+loaded_video = None
+loaded_video_path = None
 
 js_codes = ["""() => {{
             let moment_text = document.getElementById('result_{}').textContent;
@@ -81,17 +81,19 @@ js_codes = ["""() => {{
 Gradio functions
 """
 def video_upload(video):
+    global loaded_video, loaded_video_path
     if video is None:
-        model.video = None
-        model.video_path = video
+        loaded_video = None
+        loaded_video_path = video
         yield gr.update(value="Removed the video", visible=True)
     else:
         yield gr.update(value="Processing the video. Wait for a minute...", visible=True)
-        model.video = model.encode_video(video)
-        model.video_path = video
+        loaded_video = model.encode_video(video)
+        loaded_video_path = video
         yield gr.update(value="Finished video processing!", visible=True)
 
 def model_load(radio, video):
+    global loaded_video, loaded_video_path
     if radio is not None:
         loading_msg = "Loading new model. Wait for a minute..."
         yield gr.update(value=loading_msg, visible=True), gr.update(value=loading_msg, visible=True)
@@ -123,19 +125,20 @@ def model_load(radio, video):
         yield gr.update(value=load_finished_msg, visible=True), gr.update(value=encode_process_msg, visible=True)
 
         if video is not None:
-            model.video = model.encode_video(video)
-            model.video_path = video
+            loaded_video = model.encode_video(video)
+            loaded_video_path = video
             encode_finished_msg = "Finished video processing!"
             yield gr.update(value=load_finished_msg, visible=True), gr.update(value=encode_finished_msg, visible=True)
         else:
-            model.video = None
-            model.video_path = None
+            loaded_video = None
+            loaded_video_path = None
 
 def predict(textbox, line, gallery):
-    if model.video is None:
+    global loaded_video, loaded_video_path
+    if loaded_video is None:
         raise gr.Error("Upload the video before pushing the `Retrieve moment & highlight detection` button.")
     else:
-        prediction = model.predict(textbox, model.video)
+        prediction = model.predict(textbox, loaded_video)
 
         mr_results = prediction['pred_relevant_windows']
         hl_results = prediction['pred_saliency_scores']
@@ -161,7 +164,7 @@ def predict(textbox, line, gallery):
             output_path = "gradio_demo/highlight_frames/highlight_{}.png".format(i)
             (
                 ffmpeg
-                .input(model.video_path, ss=second)
+                .input(loaded_video_path, ss=second)
                 .output(output_path, vframes=1, qscale=2)
                 .global_args('-loglevel', 'quiet', '-y')
                 .run()

--- a/lighthouse/common/tr_detr_transformer.py
+++ b/lighthouse/common/tr_detr_transformer.py
@@ -138,7 +138,7 @@ class Transformer(nn.Module):
         # *Use highlight scores to suppress feature expressions in non-highlight clips
         memory_local, saliency_scores = self.HD2MR(memory_local, saliency_proj1, src, video_length, mask_local, pos_embed_local)
 
-        tgt = torch.zeros(refpoint_embed.shape[0], bs, d).cuda()
+        tgt = torch.zeros(refpoint_embed.shape[0], bs, d).to(src.device)
         hs, references = self.decoder(tgt, memory_local, memory_key_padding_mask=mask_local,
                           pos=pos_embed_local, refpoints_unsigmoid=refpoint_embed)  # (#layers, #queries, batch_size, d)
         

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -107,9 +107,9 @@ def test_video_model_prediction():
                 durations = random.sample([i for i in range(MIN_DURATION, MAX_DURATION)], SAMPLE_NUM)
                 for second in durations:
                     video_path = f'tests/test_videos/video_duration_{second}.mp4'
-                    model.encode_video(video_path)
+                    video = model.encode_video(video_path)
                     query = 'A woman wearing a glass is speaking in front of the camera'
-                    prediction = model.predict(query)
+                    prediction = model.predict(query, video)
                     assert len(prediction['pred_relevant_windows']) == MOMENT_NUM, \
                         f'The number of moments from {feature}_{model_name}_{dataset} is expected {MOMENT_NUM}, but got {len(prediction["pred_relevant_windows"])}.'
                     assert len(prediction['pred_saliency_scores']) == math.ceil(second / model._clip_len), \
@@ -134,9 +134,9 @@ def test_audio_model_prediction():
                 durations = random.sample([i for i in range(MIN_DURATION_AUDIO, MAX_DURATION_AUDIO)], SAMPLE_NUM)
                 for second in durations:
                     audio_path = f'tests/test_audios/audio_duration_{second}.wav'
-                    model.encode_audio(audio_path)
+                    audio = model.encode_audio(audio_path)
                     query = 'Water cascades down from a waterfall.'
-                    prediction = model.predict(query)
+                    prediction = model.predict(query, audio)
                     assert len(prediction['pred_relevant_windows']) == MOMENT_NUM, \
                         f'The number of moments from {feature}_{model_name}_{dataset} is expected {MOMENT_NUM}, but got {len(prediction["pred_relevant_windows"])}.'
                     assert len(prediction['pred_saliency_scores']) == math.ceil(second / model._clip_len), \


### PR DESCRIPTION
This PR is on WIP. Modifying encode_video and encode_audio API design because the current code sets video_feats/mask to the Predictor, which is buggy in gradio demo. We make the models stateless, which makes us more easier to use.